### PR TITLE
Added theme selector with Neon, Dark, Classic, Retro themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1839,9 +1839,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001667",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+      "version": "1.0.30001749",
+      "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001749.tgz",
+      "integrity": "sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==",
       "dev": true,
       "funding": [
         {
@@ -1856,7 +1856,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "2.4.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
-import { GameCanvas } from './components/GameCanvas';
-import { GameControls } from './components/GameControls';
-import { ScoreDisplay } from './components/ScoreDisplay';
-import { useSnakeGame } from './hooks/useSnakeGame';
-import { useGameLoop } from './hooks/useGameLoop';
-import { GameStatus } from './types/game';
-import { INITIAL_SPEED } from './utils/constants';
+import { GameCanvas } from "./components/GameCanvas";
+import { GameControls } from "./components/GameControls";
+import { ScoreDisplay } from "./components/ScoreDisplay";
+import { useSnakeGame } from "./hooks/useSnakeGame";
+import { useGameLoop } from "./hooks/useGameLoop";
+import { GameStatus } from "./types/game";
+import { INITIAL_SPEED, ThemeName, THEMES } from "./utils/constants";
+import { useEffect, useState } from "react";
+import { ThemeSelector } from "./components/ThemeSelector";
 
 function App() {
   const {
@@ -20,11 +22,31 @@ function App() {
     resetGame,
   } = useSnakeGame();
 
+  const [theme, setTheme] = useState<ThemeName>(
+    () => (localStorage.getItem("theme") as ThemeName) || "classic"
+  );
+
+  useEffect(() => {
+    const current = THEMES[theme];
+    Object.entries(current).forEach(([key, value]) => {
+      if (key !== "name") {
+        document.body.style.setProperty(`--${key}`, value as string);
+      }
+    });
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
   // Game loop runs only when game is playing
   useGameLoop(updateGame, INITIAL_SPEED, gameStatus === GameStatus.PLAYING);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 flex items-center justify-center p-8">
+    <div
+      className="min-h-screen flex items-center justify-center p-8 transition-colors duration-500"
+      style={{
+        backgroundColor: "var(--background)",
+        color: "var(--text)",
+      }}
+    >
       <div className="flex flex-col items-center gap-8">
         {/* Header */}
         <div className="text-center">
@@ -36,8 +58,13 @@ function App() {
           </p>
         </div>
 
+        <ThemeSelector currentTheme={theme} onThemeChange={setTheme} />
         {/* Score Display */}
-        <ScoreDisplay score={score} highScore={highScore} gameStatus={gameStatus} />
+        <ScoreDisplay
+          score={score}
+          highScore={highScore}
+          gameStatus={gameStatus}
+        />
 
         {/* Game Canvas */}
         <GameCanvas snake={snake} food={food} />
@@ -56,7 +83,9 @@ function App() {
           <h3 className="text-xl font-bold text-white mb-3">How to Play</h3>
           <ul className="space-y-2 text-sm">
             <li>• Control the snake using arrow keys or WASD</li>
-            <li>• Eat the yellow food to grow longer and increase your score</li>
+            <li>
+              • Eat the yellow food to grow longer and increase your score
+            </li>
             <li>• Avoid hitting the walls or yourself</li>
             <li>• Try to beat your high score!</li>
           </ul>

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { THEMES, ThemeName } from "../utils/constants";
+
+interface ThemeSelectorProps {
+  currentTheme: ThemeName;
+  onThemeChange: (theme: ThemeName) => void;
+}
+
+export const ThemeSelector = ({
+  currentTheme,
+  onThemeChange,
+}: ThemeSelectorProps) => {
+  const [selectedTheme, setSelectedTheme] = useState<ThemeName>(currentTheme);
+
+  useEffect(() => {
+    setSelectedTheme(currentTheme);
+  }, [currentTheme]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newTheme = event.target.value as ThemeName;
+    setSelectedTheme(newTheme);
+    onThemeChange(newTheme);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <label htmlFor="theme-selector" className="text-white font-medium">
+        Select Theme
+      </label>
+      <select
+        id="theme-selector"
+        value={selectedTheme}
+        onChange={handleChange}
+        className="px-4 py-2 rounded-lg bg-gray-800 text-white border border-gray-600 shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        {Object.entries(THEMES).map(([key, theme]) => (
+          <option key={key} value={key}>
+            {theme.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,16 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --background: #1a1a2e;
+  --grid: #16213e;
+  --snake: #0f3460;
+  --snakeHead: #e94560;
+  --food: #f39c12;
+  --text: #ffffff;
+}
+
+body {
+  transition: background-color 0.5s ease, color 0.5s ease;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,14 +9,53 @@ export const INITIAL_SPEED = 150; // Milliseconds per frame
 
 // Colors
 export const COLORS = {
-  background: '#1a1a2e',
-  grid: '#16213e',
-  snake: '#0f3460',
-  snakeHead: '#e94560',
-  food: '#f39c12',
-  text: '#ffffff',
+  background: "#1a1a2e",
+  grid: "#16213e",
+  snake: "#0f3460",
+  snakeHead: "#e94560",
+  food: "#f39c12",
+  text: "#ffffff",
 };
 
 // TODO: Add difficulty levels that adjust INITIAL_SPEED
 // TODO: Add different color themes/skins
+export const THEMES = {
+  classic: {
+    name: "Classic",
+    background: "#1a1a2e",
+    grid: "#16213e",
+    snake: "#0f3460",
+    snakeHead: "#e94560",
+    food: "#f39c12",
+    text: "#ffffff",
+  },
+  neon: {
+    name: "Neon",
+    background: "#000000",
+    grid: "#111111",
+    snake: "#00ff9d",
+    snakeHead: "#ff00ff",
+    food: "#00ffff",
+    text: "#ffffff",
+  },
+  retro: {
+    name: "Retro",
+    background: "#2b2b2b",
+    grid: "#1e1e1e",
+    snake: "#76c893",
+    snakeHead: "#f4a261",
+    food: "#e76f51",
+    text: "#e9c46a",
+  },
+  dark: {
+    name: "Dark Mode",
+    background: "#0a0a0a",
+    grid: "#1a1a1a",
+    snake: "#10b981",
+    snakeHead: "#f43f5e",
+    food: "#facc15",
+    text: "#f5f5f5",
+  },
+};
+export type ThemeName = keyof typeof THEMES;
 // TODO: Add sound effect constants for eating, game over, etc.


### PR DESCRIPTION
This PR adds a theme selector to the Snake Game, allowing users to switch between four visual themes: Classic, Neon, Retro, and Dark Mode. The selected theme is persisted in localStorage, so it remains consistent across sessions.

### Changes Made:
- Added `ThemeSelector` component with a dropdown to choose themes.
- Updated `App.tsx` to integrate the theme selector and apply CSS variables dynamically.
- Added four distinct themes in `constants.ts`:
  - Classic
  - Neon
  - Retro
  - Dark Mode
- Updated `index.css` with CSS variable definitions and smooth transition for background and text colors.
- Preserves user preference in localStorage.

### Issue Reference:
Closes #4 — Add Multiple Visual Themes

### Screenshots / Demo:
<img width="1888" height="919" alt="Screenshot 2025-10-09 232439" src="https://github.com/user-attachments/assets/a5c631c7-012f-4254-8240-b55363e6893a" />
