### PR TITLE
docs: update instructions to include pause/resume controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,6 +100,8 @@ function App() {
             </li>
             <li>• Avoid hitting the walls or yourself</li>
             <li>• Try to beat your high score!</li>
+            <li>• Press the spacebar or click the Pause/Resume button to pause or resume the game</li>
+
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Added missing instruction line to the "How to Play" section.
- Mentioned that players can press Spacebar or click Pause/Resume button.
- Matches the functionality already implemented in GameControls.
